### PR TITLE
Added BitMap expansion example

### DIFF
--- a/CDCBitMapExpansionExample/ChangeEventHeader.py
+++ b/CDCBitMapExpansionExample/ChangeEventHeader.py
@@ -1,0 +1,91 @@
+"""
+ChangeEventHeader.py
+
+This class provides the utility method to decode the bitmap fields (eg: ChangedEvents)  and return the avro schema field values represented by the bitmap.
+"""
+
+from avro.schema import Schema
+from bitstring import BitArray
+
+
+def process_bitmap(avro_schema: Schema, changed_fields: list):
+    if len(changed_fields) != 0:
+        # replace top field level bitmap with list of fields
+        if changed_fields[0].startswith("0x"):
+            bitmap = changed_fields[0]
+            changed_fields.insert(0, get_fieldnames_from_bitstring(bitmap, avro_schema))
+            changed_fields.remove(bitmap)
+        # replace parentPos-nested NulledBitMap with list of fields too
+        if "-" in changed_fields[-1]:
+            changed_field_iterator = iter(changed_fields)
+            while True:
+                try:
+                    changed_field = next(changed_field_iterator)
+                    if changed_field is not None and "-" in changed_field:
+                        bitmap_strings = changed_field.split("-")
+                        # interpret the parent field name from mapping of parentFieldPos -> childFieldbitMap
+                        parent_field = get_fields(avro_schema)[int(bitmap_strings[0])]
+                        child_schema = get_value_schema(parent_field.type)
+                        # make sure we're really dealing with compound field
+                        if child_schema.type is not None and child_schema.type == 'record':
+                            nested_size = len(get_fields(child_schema))
+                            parent_field_name = parent_field.get_prop('name')
+                            # interpret the child field names from mapping of parentFieldPos -> childFieldbitMap
+                            full_field_names = get_fieldnames_from_bitstring(bitmap_strings[1],
+                                                                             child_schema)
+                            full_field_names = append_parent_name(parent_field_name, full_field_names)
+                            if len(full_field_names) > 0:
+                                changed_fields.remove(changed_field)
+                                # when all nested fields under a compound got nulled out at once by customer, we recognize the top level field instead of trying to list every single nested field
+                                if len(full_field_names) == nested_size:
+                                    changed_fields.append(0, parent_field_name)
+                                else:
+                                    changed_fields.insert(0, full_field_names)
+                except StopIteration:
+                    break
+
+    return changed_fields
+
+
+def convert_hexbinary_to_bitset(bitmap):
+    bit_array = BitArray(hex=bitmap[2:])
+    binary_string = bit_array.bin
+    return binary_string[::-1]
+
+
+def append_parent_name(parent_field_name, full_field_names):
+    for index in range(len(full_field_names)):
+        full_field_names[index] = parent_field_name + "." + full_field_names[index]
+    return full_field_names
+
+
+def get_fieldnames_from_bitstring(bitmap, avro_schema: Schema):
+    changed_field_name = []
+    fields_list = list(avro_schema.fields_dict)
+    binary_string = convert_hexbinary_to_bitset(bitmap)
+    indexes = find('1', binary_string)
+    for index in indexes:
+        changed_field_name.append(fields_list[index])
+    return changed_field_name
+
+
+# Get the value type of an "optional" schema, which is a union of [null, valueSchema]
+def get_value_schema(parent_field):
+    if parent_field.type == 'union':
+        schemas = parent_field.schemas
+        if len(schemas) == 2 and schemas[0].type == 'null':
+            return schemas[1]
+        if len(schemas) == 2 and schemas[0].type == 'string':
+            return schemas[1]
+        if len(schemas) == 3 and schemas[0].type == 'null' and schemas[1].type == 'string':
+            return schemas[2]
+    return parent_field
+
+
+# Find the positions of 1 in the bit string
+def find(to_find, binary_string):
+    return [i for i, x in enumerate(binary_string) if x == to_find]
+
+
+def get_fields(schema: Schema):
+    return schema.get_prop('fields')

--- a/CDCBitMapExpansionExample/ChangeEventHeaderUtility.py
+++ b/CDCBitMapExpansionExample/ChangeEventHeaderUtility.py
@@ -1,5 +1,5 @@
 """
-ChangeEventHeader.py
+ChangeEventHeaderUtility.py
 
 This class provides the utility method to decode the bitmap fields (eg: ChangedEvents)  and return the avro schema field values represented by the bitmap.
 """
@@ -8,21 +8,21 @@ from avro.schema import Schema
 from bitstring import BitArray
 
 
-def process_bitmap(avro_schema: Schema, changed_fields: list):
-    if len(changed_fields) != 0:
+def process_bitmap(avro_schema: Schema, bitmap_fields: list):
+    if len(bitmap_fields) != 0:
         # replace top field level bitmap with list of fields
-        if changed_fields[0].startswith("0x"):
-            bitmap = changed_fields[0]
-            changed_fields.insert(0, get_fieldnames_from_bitstring(bitmap, avro_schema))
-            changed_fields.remove(bitmap)
-        # replace parentPos-nested NulledBitMap with list of fields too
-        if "-" in changed_fields[-1]:
-            changed_field_iterator = iter(changed_fields)
+        if bitmap_fields[0].startswith("0x"):
+            bitmap = bitmap_fields[0]
+            bitmap_fields.insert(0, get_fieldnames_from_bitstring(bitmap, avro_schema))
+            bitmap_fields.remove(bitmap)
+        # replace parentPos-nested Nulled BitMap with list of fields too
+        if "-" in bitmap_fields[-1]:
+            bitmap_field_iterator = iter(bitmap_fields)
             while True:
                 try:
-                    changed_field = next(changed_field_iterator)
-                    if changed_field is not None and "-" in changed_field:
-                        bitmap_strings = changed_field.split("-")
+                    bitmap_field = next(bitmap_field_iterator)
+                    if bitmap_field is not None and "-" in bitmap_field:
+                        bitmap_strings = bitmap_field.split("-")
                         # interpret the parent field name from mapping of parentFieldPos -> childFieldbitMap
                         parent_field = get_fields(avro_schema)[int(bitmap_strings[0])]
                         child_schema = get_value_schema(parent_field.type)
@@ -35,16 +35,16 @@ def process_bitmap(avro_schema: Schema, changed_fields: list):
                                                                              child_schema)
                             full_field_names = append_parent_name(parent_field_name, full_field_names)
                             if len(full_field_names) > 0:
-                                changed_fields.remove(changed_field)
+                                bitmap_fields.remove(bitmap_field)
                                 # when all nested fields under a compound got nulled out at once by customer, we recognize the top level field instead of trying to list every single nested field
                                 if len(full_field_names) == nested_size:
-                                    changed_fields.append(0, parent_field_name)
+                                    bitmap_fields.append(0, parent_field_name)
                                 else:
-                                    changed_fields.insert(0, full_field_names)
+                                    bitmap_fields.insert(0, full_field_names)
                 except StopIteration:
                     break
 
-    return changed_fields
+    return bitmap_fields
 
 
 def convert_hexbinary_to_bitset(bitmap):
@@ -60,13 +60,13 @@ def append_parent_name(parent_field_name, full_field_names):
 
 
 def get_fieldnames_from_bitstring(bitmap, avro_schema: Schema):
-    changed_field_name = []
+    bitmap_field_name = []
     fields_list = list(avro_schema.fields_dict)
     binary_string = convert_hexbinary_to_bitset(bitmap)
     indexes = find('1', binary_string)
     for index in indexes:
-        changed_field_name.append(fields_list[index])
-    return changed_field_name
+        bitmap_field_name.append(fields_list[index])
+    return bitmap_field_name
 
 
 # Get the value type of an "optional" schema, which is a union of [null, valueSchema]

--- a/CDCBitMapExpansionExample/SubscribeEvents.py
+++ b/CDCBitMapExpansionExample/SubscribeEvents.py
@@ -1,0 +1,49 @@
+import os, sys, time, avro
+
+dir_path = os.path.dirname(os.path.realpath(__file__))
+parent_dir_path = os.path.abspath(os.path.join(dir_path, os.pardir))
+sys.path.insert(0, parent_dir_path)
+
+from utils.ClientUtil import *
+from ChangeEventHeader import process_bitmap
+from PubSub import PubSub
+
+
+latest_replay_id = None
+
+def process_events(event, pubsub):
+    if event.events:
+        payload_bytes = event.events[0].event.payload
+        json_schema = pubsub.get_schema_json(event.events[0].event.schema_id)
+        decoded_event = pubsub.decode(json_schema, payload_bytes)
+        print("Got events!", decoded_event)
+        if 'ChangeEventHeader' in decoded_event:
+            changed_fields = decoded_event['ChangeEventHeader']['changedFields']
+            print("=========== Changed Fields =============")
+            print(process_bitmap(avro.schema.parse(json_schema), changed_fields))
+            print("=========================================")
+    else:
+        print("[", time.strftime('%b %d, %Y %l:%M%p %Z'), "] The subscription is active.")
+
+    # The replay_id is used to resubscribe after this position in the stream if the client disconnects.
+    latest_replay_id = event.latest_replay_id
+
+
+def subscribe(argument_dict):
+    pubsub = PubSub(argument_dict)
+    pubsub.auth()
+
+    topic = pubsub.get_topic(pubsub.topic_name)
+
+    # Get Schema Id from the topic
+    schema = pubsub.get_schema_json(topic.schema_id)
+    print("Schema = ", schema)
+
+    # Subscribe
+    print("=============== Starting Subscription ===============")
+    pubsub.subscribe(pubsub.topic_name, process_events)
+
+
+if __name__ == "__main__":
+    argument_dict = command_line_input(sys.argv[1:])
+    subscribe(argument_dict)

--- a/CDCBitMapExpansionExample/SubscribeEvents.py
+++ b/CDCBitMapExpansionExample/SubscribeEvents.py
@@ -5,7 +5,7 @@ parent_dir_path = os.path.abspath(os.path.join(dir_path, os.pardir))
 sys.path.insert(0, parent_dir_path)
 
 from utils.ClientUtil import *
-from ChangeEventHeader import process_bitmap
+from ChangeEventHeaderUtility import process_bitmap
 from PubSub import PubSub
 
 
@@ -18,6 +18,7 @@ def process_events(event, pubsub):
         decoded_event = pubsub.decode(json_schema, payload_bytes)
         print("Got events!", decoded_event)
         if 'ChangeEventHeader' in decoded_event:
+            # An example to process bitmap in 'changedFields'
             changed_fields = decoded_event['ChangeEventHeader']['changedFields']
             print("=========== Changed Fields =============")
             print(process_bitmap(avro.schema.parse(json_schema), changed_fields))


### PR DESCRIPTION
Change events contain bitmap fields, such as changedFields. These fields are not readable when printed after the event is deserialized because their structure is a bitmap.